### PR TITLE
Add Subscribe support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,7 @@ Simple clash premiun core installer with full tun support for Linux.
 
 <br/><br/><br/>
 **If you do not set clash subscribe link or want to change clash subscribe link, Please edit `/usr/lib/systemd/system/clash.service` . When finished please run `systemctl daemon-reload`**
+
+### Clash web
+
+[clash.razord.top](http://clash.razord.top/)

--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ Simple clash premiun core installer with full tun support for Linux.
 
 3. Download clash core [link](https://github.com/Dreamacro/clash/releases/tag/premium)
 
-4. Extract core and rename it to `./clash`
+4. Extract core and rename it to `./clash` (the clash core should in the 'clash-premium-installer' folder)
 
-5. Run Installer
+5. Edit `./scripts/clash.service` and set your `CLASH_URL` (note that subscribe address shouldn't have "&" symbol, if it have, you should convert it to a short url)
+
+6. Run Installer
 
    ```bash
    ./installer.sh install

--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@ Simple clash premiun core installer with full tun support for Linux.
    ```bash
    ./installer.sh install
    ```
+
+
+<br/><br/><br/>
+**If you do not set clash subscribe link or want to change clash subscribe link, Please edit `/usr/lib/systemd/system/clash.service` . When finished please run `systemctl daemon-reload`**

--- a/installer.sh
+++ b/installer.sh
@@ -58,6 +58,10 @@ function _install() {
     assert install -m 0700 scripts/setup-tun.sh /usr/lib/clash/setup-tun.sh
     assert install -m 0700 scripts/setup-cgroup.sh /usr/lib/clash/setup-cgroup.sh
 
+    assert install -m 0700 scripts/start-clash.sh /srv/clash/start-clash.sh
+    assert install -m 0700 scripts/stop-clash.sh /srv/clash/stop-clash.sh
+    assert install -m 0644 scripts/append.yaml /srv/clash/append.yaml
+
     assert install -m 0644 scripts/clash.service /usr/lib/systemd/system/clash.service
     assert install -m 0644 scripts/99-clash.rules /usr/lib/udev/rules.d/99-clash.rules
 
@@ -65,8 +69,10 @@ function _install() {
     echo ""
     echo "Home directory at /srv/clash"
     echo ""
-    echo "All dns traffic will be redirected to 1.0.0.1:53"
-    echo "Please use clash core's 'tun.dns-hijack' to handle it"
+    echo "If you do not set clash subscribe link or want to change clash subscribe link"
+    echo "Please edit '/usr/lib/systemd/system/clash.service' . When finished please run 'systemctl daemon-reload' "
+    # echo "All dns traffic will be redirected to 1.0.0.1:53"
+    # echo "Please use clash core's 'tun.dns-hijack' to handle it"
     echo ""
     echo "Use 'systemctl start clash' to start"
     echo "Use 'systemctl enable clash' to enable auto-restart on boot"
@@ -88,6 +94,9 @@ function _uninstall() {
     rm -rf /usr/bin/bypass-proxy-uid
     rm -rf /usr/bin/bypass-proxy
     rm -rf /etc/default/clash
+    rm -rf /srv/clash/start-clash.sh
+    rm -rf /srv/clash/stop-clash.sh
+    rm -rf /srv/clash/append.yaml
 
     echo "Uninstall successfully"
 
@@ -95,7 +104,7 @@ function _uninstall() {
 }
 
 function _help() {
-    echo "Clash Premiun Installer"
+    echo "Clash Premiun Installer(Please run as root!)"
     echo ""
     echo "Usage: ./installer.sh [option]"
     echo ""

--- a/scripts/append.yaml
+++ b/scripts/append.yaml
@@ -1,0 +1,18 @@
+# =i-g-n-o-r-e= # this file will auto append to your clash subscribe config file
+# =i-g-n-o-r-e=
+dns: # =i-g-n-o-r-e=
+  enable: true # =i-g-n-o-r-e=
+  listen: 0.0.0.0:1053 # =i-g-n-o-r-e=
+  # fake-ip-range: 198.18.0.1/16 # =i-g-n-o-r-e=
+  enhanced-mode: redir-host # =i-g-n-o-r-e=
+  nameserver: # =i-g-n-o-r-e=
+    - 114.114.114.114 # =i-g-n-o-r-e=
+# =i-g-n-o-r-e=
+tun: # =i-g-n-o-r-e=
+  enable: true # =i-g-n-o-r-e=
+  #stack: system # =i-g-n-o-r-e=
+  stack: gvisor # =i-g-n-o-r-e=
+  dns-hijack: # =i-g-n-o-r-e=
+    - 1.0.0.1:53 # =i-g-n-o-r-e=
+# =i-g-n-o-r-e=
+interface-name: enp0s3 # =i-g-n-o-r-e=

--- a/scripts/clash.service
+++ b/scripts/clash.service
@@ -1,11 +1,19 @@
 [Unit]
-Description=A rule based proxy tunnel
+Description=A rule based proxy tunnel (with subscribe)
 After=network-online.target nftables.service iptabels.service
 
 [Service]
 Type=simple
+WorkingDirectory=/srv/clash
 ExecStartPre=+/usr/lib/clash/setup-cgroup.sh
-ExecStart=/usr/bin/bypass-proxy /usr/bin/clash -d /srv/clash
+# ExecStart=/usr/bin/bypass-proxy /usr/bin/clash -d /srv/clash
+ExecStart=/srv/clash/start-clash.sh
+ExecStop=/srv/clash/stop-clash.sh
+Environment="CLASH_HOME=/srv/clash"
+
+Environment="CLASH_URL=http://127.0.0.1:8080/sub" # http://127.0.0.1:8080/sub is your subscribe address. 
+# note that subscribe address shouldn't have "&" symbol, 
+# if it have, you should convert it to a short url
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/clash.service
+++ b/scripts/clash.service
@@ -11,7 +11,8 @@ ExecStart=/srv/clash/start-clash.sh
 ExecStop=/srv/clash/stop-clash.sh
 Environment="CLASH_HOME=/srv/clash"
 
-Environment="CLASH_URL=http://127.0.0.1:8080/sub" # http://127.0.0.1:8080/sub is your subscribe address. 
+Environment="CLASH_URL=http://127.0.0.1:8080/sub" 
+# http://127.0.0.1:8080/sub is your subscribe address. 
 # note that subscribe address shouldn't have "&" symbol, 
 # if it have, you should convert it to a short url
 

--- a/scripts/start-clash.sh
+++ b/scripts/start-clash.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# save this file to ${CLASH_HOME}/start-clash.sh
+
+# save pid file
+echo $$ > ${CLASH_HOME}/clash.pid
+
+diff --ignore-matching-lines "=i-g-n-o-r-e=" ${CLASH_HOME}/config.yaml <(curl -L -s ${CLASH_URL})
+if [ "$?" == 0 ]
+then
+    /usr/bin/bypass-proxy /usr/bin/clash -d /srv/clash
+else
+    TIME=`date '+%Y-%m-%d_%H:%M:%S'`
+    cp ${CLASH_HOME}/config.yaml "${CLASH_HOME}/config.yaml.bak${TIME}"
+    curl -L -o ${CLASH_HOME}/config.yaml ${CLASH_URL}
+    /usr/bin/bypass-proxy /usr/bin/clash -d /srv/clash
+fi

--- a/scripts/start-clash.sh
+++ b/scripts/start-clash.sh
@@ -12,5 +12,6 @@ else
     TIME=`date '+%Y-%m-%d_%H:%M:%S'`
     cp ${CLASH_HOME}/config.yaml "${CLASH_HOME}/config.yaml.bak${TIME}"
     curl -L -o ${CLASH_HOME}/config.yaml ${CLASH_URL}
+    cat ${CLASH_HOME}/append.yaml >> ${CLASH_HOME}/config.yaml
     /usr/bin/bypass-proxy /usr/bin/clash -d /srv/clash
 fi

--- a/scripts/stop-clash.sh
+++ b/scripts/stop-clash.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# save this file to ${CLASH_HOME}/stop-clash.sh
+
+# read pid file
+PID=`cat ${CLASH_HOME}/clash.pid`
+kill -9 ${PID}
+rm ${CLASH_HOME}/clash.pid


### PR DESCRIPTION
User can config `scripts/clash.service (Environment="CLASH_URL=")` before install to set a clash subscribe link.

Then run `./installer.sh install` to install clash premium and  run it with `systemctl start clash` or `service clash start` to auto set `config.yaml`

(Suggest) *If user have installed clash premium with no subscribe support before, should run `./installer.sh uninstall` then install it again.*