### PR TITLE
installer: systemctl does not need assert

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -88,7 +88,7 @@ function _install() {
 
     _remove_legacy_files
 
-    assert systemctl disable --now clash
+    systemctl disable --now clash
     
     assert install -d -m 0755 /etc/default/
     assert install -d -m 0755 /usr/lib/clash/


### PR DESCRIPTION
The clash service does not exist, it will cause failure to install.